### PR TITLE
[backend] update: label task can keep_annotations for now

### DIFF
--- a/ymir/backend/src/ymir-app/app/schemas/task.py
+++ b/ymir/backend/src/ymir-app/app/schemas/task.py
@@ -43,6 +43,7 @@ class TaskParameter(BaseModel):
     # label
     extra_url: Optional[str]
     labellers: Optional[List[EmailStr]]
+    keep_annotations: Optional[bool]
 
     # training
     network: Optional[str]

--- a/ymir/backend/src/ymir-app/app/utils/ymir_controller.py
+++ b/ymir/backend/src/ymir-app/app/utils/ymir_controller.py
@@ -202,6 +202,7 @@ class ControllerRequest:
         label_request.dataset_id = args["include_datasets"][0]
         label_request.labeler_accounts[:] = args["labellers"]
         label_request.in_class_ids[:] = args["include_classes"]
+        label_request.export_annotation = args["keep_annotations"]
         if args.get("extra_url"):
             label_request.expert_instruction_url = args["extra_url"]
 

--- a/ymir/backend/src/ymir-app/tests/utils/test_controller.py
+++ b/ymir/backend/src/ymir-app/tests/utils/test_controller.py
@@ -95,10 +95,12 @@ class TestControllerRequest:
                 "labellers": [],
                 "include_classes": [],
                 "extra_url": random_url(),
+                "keep_annotations": True,
             },
         )
         assert ret.req.req_type == m.mirsvrpb.TASK_CREATE
         assert ret.req.req_create_task.task_type == m.mirsvrpb.TaskTypeLabel
+        assert ret.req.req_create_task.labeling.export_annotation
 
     def test_copy_data(self):
         task_type = m.TaskType.copy_data


### PR DESCRIPTION
- [x] use updated protobuf which include `keep_annotations` and the like