### PR TITLE
[backend] add docker_image_id to task_parameter

### DIFF
--- a/ymir/backend/src/ymir-app/app/schemas/task.py
+++ b/ymir/backend/src/ymir-app/app/schemas/task.py
@@ -58,6 +58,8 @@ class TaskParameter(BaseModel):
 
     # training & mining & infer
     docker_image: Optional[str]
+    # todo replace docker_image with docker_image_id
+    docker_image_id: Optional[int]
 
 
 class TaskCreate(TaskBase):


### PR DESCRIPTION
frontend need docker_image_id while parsing task parameter