### PR TITLE
[backend] do not terminate task type in whitelist upon start up

### DIFF
--- a/ymir/backend/src/ymir-app/app/clean_tasks.py
+++ b/ymir/backend/src/ymir-app/app/clean_tasks.py
@@ -35,6 +35,9 @@ def terminate_tasks() -> None:
         if not (task.hash and task.type):
             # make mypy happy
             continue
+        if task.type in settings.TASK_TYPES_WHITELIST:
+            # do not terminate task having whitelist type
+            continue
         try:
             controller.terminate_task(
                 user_id=user.id, task_hash=task.hash, task_type=task.type

--- a/ymir/backend/src/ymir-app/app/config.py
+++ b/ymir/backend/src/ymir-app/app/config.py
@@ -76,5 +76,9 @@ class Settings(BaseSettings):
     GITHUB_TIMEOUT: int = 30
     APP_CACHE_EXPIRE_IN_SECONDS: int = 3600
 
+    # Task Type To Survive Upon Start up
+    #  default TaskTypeLabel = 3
+    TASK_TYPES_WHITELIST: List[int] = [3]
+
 
 settings = Settings(_env_file=".env")  # type: ignore


### PR DESCRIPTION
Keep task of type listed in `TASK_TYPES_WHITELIST` alive upon start up, default to label task, which is 3.