### PR TITLE
[backend] handle duplicated model hash properly

### DIFF
--- a/ymir/backend/src/ymir_app/app/crud/base.py
+++ b/ymir/backend/src/ymir_app/app/crud/base.py
@@ -139,4 +139,16 @@ class CRUDBase(Generic[ModelType, CreateSchemaType, UpdateSchemaType]):
         return db.query(self.model).count()
 
     def is_duplicated_name(self, db: Session, user_id: int, name: str) -> bool:
-        return not (self.get_by_user_and_name(db, user_id, name) is None)
+        return self.get_by_user_and_name(db, user_id, name) is not None
+
+    def is_duplicated_hash(self, db: Session, project_id: int, hash_: str) -> bool:
+        existing = (
+            db.query(self.model)
+            .filter(
+                self.model.project_id == project_id,  # type: ignore
+                self.model.hash == hash_,  # type: ignore
+                not_(self.model.is_deleted),  # type: ignore
+            )
+            .one_or_none()
+        )
+        return existing is not None

--- a/ymir/backend/src/ymir_app/app/crud/crud_model.py
+++ b/ymir/backend/src/ymir_app/app/crud/crud_model.py
@@ -145,11 +145,17 @@ class CRUDModel(CRUDBase[Model, ModelCreate, ModelUpdate]):
         model = self.get(db, id=model_id)
         if not model:
             return model
-        model.result_state = int(result_state)
 
         if result:
             model.map = result["map"]
-            model.hash = result["hash"]
+
+            # avoid duplicated model hash within the same project
+            if self.is_duplicated_hash(db, model.project_id, result["hash"]):
+                result_state = ResultState.error
+            else:
+                model.hash = result["hash"]
+
+        model.result_state = int(result_state)
 
         db.add(model)
         db.commit()


### PR DESCRIPTION
We cannot enforce unique (model_hash, project_id) upon importing model request, model_hash not known at that time.
Just set the duplicated model to error state before it's too late.