### PR TITLE
[backend] fix model parameters

### DIFF
--- a/ymir/backend/src/ymir_app/app/api/api_v1/endpoints/tasks.py
+++ b/ymir/backend/src/ymir_app/app/api/api_v1/endpoints/tasks.py
@@ -1,6 +1,5 @@
 from dataclasses import asdict
 import enum
-import json
 from typing import Any, Dict, List, Optional, Union, Tuple
 
 from fastapi import APIRouter, Depends, Path, Query
@@ -323,13 +322,12 @@ class TaskResult:
             return
 
         if task_result.state is TaskState.done:
-            # import model has no parameters, only update this task
             if isinstance(self.result_info, ModelMetaData):
                 crud.task.update_parameters_and_config(
                     self.db,
                     task=task_in_db,
-                    parameters=json.dumps(self.result_info.task_parameters),
-                    config=json.dumps(self.result_info.executor_config),
+                    parameters=self.result_info.task_parameters,
+                    config=self.result_info.executor_config,
                 )
             crud_func.finish(
                 self.db,


### PR DESCRIPTION
`task_parameters` and `executor_config` are json dumped string already.