### PR TITLE
[command] fix export and training issue

### DIFF
--- a/docker_executor/sample_executor/app/start.py
+++ b/docker_executor/sample_executor/app/start.py
@@ -41,6 +41,8 @@ def _run_training(env_config: env.EnvConfig) -> None:
     #! use `dataset_reader.item_paths` to read training or validation dataset items
     #!  note that `dataset_reader.item_paths` is a generator
     for asset_path, annotation_path in dr.item_paths(dataset_type=env.DatasetType.TRAINING):
+        if not os.path.isfile(asset_path):
+            raise FileNotFoundError(f"file not found: {asset_path}")
         logging.info(f"asset: {asset_path}, annotation: {annotation_path}")
 
     #! use `monitor.write_monitor_logger` to write write task process percent to monitor.txt

--- a/ymir/command/mir/commands/exporting.py
+++ b/ymir/command/mir/commands/exporting.py
@@ -95,7 +95,7 @@ class CmdExport(base.BaseCommand):
                                            class_ids_mapping=class_type_ids,
                                            format_type=anno_format_type,
                                            index_file_path=os.path.join(annotation_dir, 'index.tsv'),
-                                           gt_index_file_path=os.path.join(gt_dir, 'index.tsv'))
+                                           gt_index_file_path=os.path.join(gt_dir, 'index.tsv') if gt_dir else '')
         elif asset_format_type == data_writer.AssetFormat.ASSET_FORMAT_LMDB:
             dw = data_writer.LmdbDataWriter(mir_root=mir_root,
                                             assets_location=media_location,
@@ -141,7 +141,7 @@ def bind_to_subparsers(subparsers: argparse._SubParsersAction, parent_parser: ar
                                       type=str,
                                       help="export directory for annotations")
     exporting_arg_parser.add_argument("--gt-dir",
-                                      required=True,
+                                      required=False,
                                       dest="gt_dir",
                                       type=str,
                                       help="export directory for ground-truth")

--- a/ymir/command/mir/commands/training.py
+++ b/ymir/command/mir/commands/training.py
@@ -433,6 +433,7 @@ class CmdTrain(base.BaseCommand):
             _execute_training(
                 work_dir_in=work_dir_in,
                 work_dir_out=work_dir_out,
+                asset_cache_dir=asset_cache_dir,
                 executor=executor,
                 executant_name=executant_name,
                 executor_config=executor_config,
@@ -497,6 +498,7 @@ class CmdTrain(base.BaseCommand):
 
 def _execute_training(work_dir_in: str,
                       work_dir_out: str,
+                      asset_cache_dir: str,
                       executor: str,
                       executant_name: str,
                       executor_config: Dict,
@@ -522,6 +524,7 @@ def _execute_training(work_dir_in: str,
         _execute_locally(
             work_dir_in=work_dir_in,
             work_dir_out=work_dir_out,
+            asset_cache_dir=asset_cache_dir,
             executor=executor,
             executant_name=executant_name,
             executor_config=executor_config,
@@ -559,11 +562,14 @@ def _execute_locally(
     executor_config: Dict,
     available_gpu_id: str,
     run_as_root: bool = False,
+    asset_cache_dir: str = '',
 ) -> None:
     # start train docker and wait
     path_binds = []
     path_binds.append(f"-v{work_dir_in}:/in")  # annotations, models, train-index.tsv, val-index.tsv, config.yaml
     path_binds.append(f"-v{work_dir_out}:/out")
+    if asset_cache_dir:
+        path_binds.append(f"-v{asset_cache_dir}:{asset_cache_dir}")
 
     cmd = [
         mir_utils.get_docker_executable(gpu_ids=available_gpu_id), 'run', '--rm',

--- a/ymir/command/mir/commands/training.py
+++ b/ymir/command/mir/commands/training.py
@@ -190,7 +190,7 @@ class CmdTrain(base.BaseCommand):
     @staticmethod
     @command_run_in_out
     def run_with_args(work_dir: str,
-                      asset_cache_dir: Optional[str],
+                      asset_cache_dir: str,
                       model_upload_location: str,
                       pretrained_model_hash_stage: str,
                       executor: str,
@@ -611,6 +611,7 @@ def bind_to_subparsers(subparsers: argparse._SubParsersAction, parent_parser: ar
                                   required=False,
                                   dest='asset_cache_dir',
                                   type=str,
+                                  default='',
                                   help='asset cache directory')
     train_arg_parser.add_argument("--executor",
                                   required=True,


### PR DESCRIPTION
# bug fixed
* when create labeling task, mir export raised error, see http://192.168.2.150:81/zentao/bug-view-68515.html
* when training locally with --assets-cache set, docker container can not find image, see http://192.168.2.150:81/zentao/bug-view-68504.html