### PR TITLE
[command] fix infer bug

### DIFF
--- a/docker_executor/sample_executor/app/start.py
+++ b/docker_executor/sample_executor/app/start.py
@@ -46,10 +46,14 @@ def _run_training(env_config: env.EnvConfig) -> None:
 
     #! use `dataset_reader.item_paths` to read training or validation dataset items
     #!  note that `dataset_reader.item_paths` is a generator
+    absent_count = 0
     for asset_path, annotation_path in dr.item_paths(dataset_type=env.DatasetType.TRAINING):
-        if not os.path.isfile(asset_path):
-            raise FileNotFoundError(f"file not found: {asset_path}")
-        logging.info(f"asset: {asset_path}, annotation: {annotation_path}")
+        isfile = os.path.isfile(asset_path)
+        if not isfile:
+            absent_count += 1
+        logging.info(f"asset: {asset_path}, is file: {isfile}; "
+                     f"annotation: {annotation_path}, is file: {os.path.isfile(annotation_path)}")
+    logging.info(f"absent: {absent_count}")
 
     #! use `monitor.write_monitor_logger` to write write task process percent to monitor.txt
     monitor.write_monitor_logger(percent=0.5)
@@ -93,15 +97,19 @@ def _run_mining(env_config: env.EnvConfig) -> None:
     #! use `dataset_reader.item_paths` to read candidate dataset items
     #   note that annotations path will be empty str if there's no annotations in that dataset
     asset_paths = []
+    absent_count = 0
     for asset_path, _ in dr.item_paths(dataset_type=env.DatasetType.CANDIDATE):
-        logging.info(f"asset: {asset_path}")
+        isfile = os.path.isfile(asset_path)
+        if not isfile:
+            absent_count += 1
+        logging.info(f"asset: {asset_path}, is file: {isfile}")
         asset_paths.append(asset_path)
 
     if len(asset_paths) == 0:
         raise ValueError('empty asset paths')
 
     #! use `monitor.write_monitor_logger` to write task process to monitor.txt
-    logging.info(f"assets count: {len(asset_paths)}")
+    logging.info(f"assets count: {len(asset_paths)}, absent: {absent_count}")
     monitor.write_monitor_logger(percent=0.5)
 
     _dummy_work(idle_seconds=idle_seconds, trigger_crash=trigger_crash)
@@ -132,15 +140,19 @@ def _run_infer(env_config: env.EnvConfig) -> None:
     #! use `dataset_reader.item_paths` to read candidate dataset items
     #   note that annotations path will be empty str if there's no annotations in that dataset
     asset_paths: List[str] = []
+    absent_count = 0
     for asset_path, _ in dr.item_paths(dataset_type=env.DatasetType.CANDIDATE):
-        logging.info(f"asset: {asset_path}")
+        isfile = os.path.isfile(asset_path)
+        if not isfile:
+            absent_count += 1
+        logging.info(f"asset: {asset_path}, exists: {isfile}")
         asset_paths.append(asset_path)
 
     if len(asset_paths) == 0 or len(class_names) == 0:
         raise ValueError('empty asset paths or class names')
 
     #! use `monitor.write_monitor_logger` to write log to console and write task process percent to monitor.txt
-    logging.info(f"assets count: {len(asset_paths)}")
+    logging.info(f"assets count: {len(asset_paths)}, absent: {absent_count}")
     monitor.write_monitor_logger(percent=0.5)
 
     _dummy_work(idle_seconds=idle_seconds, trigger_crash=trigger_crash)

--- a/docker_executor/sample_executor/app/start.py
+++ b/docker_executor/sample_executor/app/start.py
@@ -145,7 +145,7 @@ def _run_infer(env_config: env.EnvConfig) -> None:
         isfile = os.path.isfile(asset_path)
         if not isfile:
             absent_count += 1
-        logging.info(f"asset: {asset_path}, exists: {isfile}")
+        logging.info(f"asset: {asset_path}, is file: {isfile}")
         asset_paths.append(asset_path)
 
     if len(asset_paths) == 0 or len(class_names) == 0:

--- a/ymir/backend/src/ymir_controller/controller/invoker/invoker_cmd_inference.py
+++ b/ymir/backend/src/ymir_controller/controller/invoker/invoker_cmd_inference.py
@@ -36,7 +36,7 @@ class InferenceCMDInvoker(BaseMirControllerInvoker):
 
     @classmethod
     def prepare_inference_picture(cls, source_path: str, work_dir: str) -> str:
-        inference_picture_directory = os.path.join(work_dir, "inference_picture")
+        inference_picture_directory = os.path.join(work_dir, "assets")
         os.makedirs(inference_picture_directory, exist_ok=True)
 
         for root, _, files in os.walk(source_path):

--- a/ymir/command/mir/commands/infer.py
+++ b/ymir/command/mir/commands/infer.py
@@ -39,7 +39,7 @@ class CmdInfer(base.BaseCommand):
 
         return CmdInfer.run_with_args(work_dir=self.args.work_dir,
                                       mir_root=self.args.mir_root,
-                                      media_path=os.path.join(self.args.work_dir, 'assets'),
+                                      media_path=self.args.work_dir,
                                       model_location=self.args.model_location,
                                       model_hash_stage=self.args.model_hash_stage,
                                       index_file=self.args.index_file,

--- a/ymir/command/mir/commands/infer.py
+++ b/ymir/command/mir/commands/infer.py
@@ -39,7 +39,7 @@ class CmdInfer(base.BaseCommand):
 
         return CmdInfer.run_with_args(work_dir=self.args.work_dir,
                                       mir_root=self.args.mir_root,
-                                      media_path=self.args.work_dir,
+                                      media_path=os.path.join(self.args.work_dir, 'assets'),
                                       model_location=self.args.model_location,
                                       model_hash_stage=self.args.model_hash_stage,
                                       index_file=self.args.index_file,
@@ -290,7 +290,7 @@ def bind_to_subparsers(subparsers: argparse._SubParsersAction, parent_parser: ar
                                   required=True,
                                   dest='work_dir',
                                   type=str,
-                                  help='work place for mining and monitoring')
+                                  help='work place for this command, all images should put to <work_dir>/assets')
     infer_arg_parser.add_argument('--model-location',
                                   required=True,
                                   dest='model_location',

--- a/ymir/command/tests/unit/test_cmd_infer.py
+++ b/ymir/command/tests/unit/test_cmd_infer.py
@@ -22,7 +22,7 @@ class TestCmdInfer(unittest.TestCase):
         self._mir_repo_root = os.path.join(self._test_root, 'mir-demo-repo')
         self._working_root = os.path.join(self._test_root, 'work')  # work directory for cmd infer
         self._models_location = os.path.join(self._working_root, 'models')
-        self._src_assets_root = self._working_root  # source assets, index and infer config file
+        self._src_assets_root = os.path.join(self._working_root, 'assets')  # source assets, index and infer config file
         self._config_file = os.path.join(self._working_root, 'config.yaml')
         self._assets_index_file = os.path.join(self._working_root, 'index.tsv')
 

--- a/ymir/command/tests/unit/test_cmd_infer.py
+++ b/ymir/command/tests/unit/test_cmd_infer.py
@@ -22,7 +22,7 @@ class TestCmdInfer(unittest.TestCase):
         self._mir_repo_root = os.path.join(self._test_root, 'mir-demo-repo')
         self._working_root = os.path.join(self._test_root, 'work')  # work directory for cmd infer
         self._models_location = os.path.join(self._working_root, 'models')
-        self._src_assets_root = os.path.join(self._working_root, 'assets')  # source assets, index and infer config file
+        self._src_assets_root = self._working_root  # source assets, index and infer config file
         self._config_file = os.path.join(self._working_root, 'config.yaml')
         self._assets_index_file = os.path.join(self._working_root, 'index.tsv')
 


### PR DESCRIPTION
# how to reproduce
* start an infer task and you'll find error message in ymir-executor-out.log shows that asset file not found
# root cause
* controller: infer cmd invoker:
  * copy all images to <work_dir>/assets
  * call cmd infer, passing <work_dir>/assets to arg: --media-path
  * this breaks the promise that 'all images are in media_path', and cause trouble