### PR TITLE
[command] fix MirStorageOps load_assets_content issue

### DIFF
--- a/ymir/command/mir/tools/mir_storage_ops.py
+++ b/ymir/command/mir/tools/mir_storage_ops.py
@@ -517,7 +517,7 @@ class MirStorageOps():
             all_asset_ids=sorted([*mir_storage_metadatas["attributes"].keys()]),  # ordered list.
             asset_ids_detail=asset_ids_detail,
             class_ids_index={
-                k: list(v.get('key_ids', {}).keys())
+                k: list(v.get('key_ids', {}))
                 for k, v in mir_storage_keywords.get('pred_idx', {}).get('cis', {}).items()
             },
         )

--- a/ymir/command/mir/tools/mir_storage_ops.py
+++ b/ymir/command/mir/tools/mir_storage_ops.py
@@ -516,8 +516,10 @@ class MirStorageOps():
         return dict(
             all_asset_ids=sorted([*mir_storage_metadatas["attributes"].keys()]),  # ordered list.
             asset_ids_detail=asset_ids_detail,
-            class_ids_index={k: list(v["key_ids"].keys())
-                             for k, v in mir_storage_keywords["pred_idx"]['cis'].items()},
+            class_ids_index={
+                k: list(v.get('key_ids', {}).keys())
+                for k, v in mir_storage_keywords.get('pred_idx', {}).get('cis', {}).items()
+            },
         )
 
     @classmethod


### PR DESCRIPTION
# how to reproduce
* import a dataset without annotations and ground truth
* go to browse dataset images and you can find ymir_viz raises KeyError: pred_idx

# reason
* MessageToDict documentation shows:

including_default_value_fields – If True, singular primitive fields, repeated fields, and map fields will always be serialized. If False, only serialize non-empty fields. **Singular message fields and oneof fields are not affected by this option.**

* so `pred_idx` will not appear in dict

# any where else to change?
I searched all `load_multiple_stages` and `load_single_stage` with `as_dict=True`, only find here need to be changed