### PR TITLE
[51-plugin] fix voxel51 cm crash

### DIFF
--- a/plugin/fiftyone/app/worker.py
+++ b/plugin/fiftyone/app/worker.py
@@ -168,7 +168,8 @@ def _build_polylines(voc_objects: list, width: int, height: int) -> List[Polylin
             confidence=obj.get("confidence"),
             closed=True
         )
-        polyline.tags.append(obj["cm"])
+        if obj.get("cm"):
+            polyline.tags.append(obj["cm"])
         polyline["box_quality"] = obj["box_quality"]
         polyline["difficult"] = obj["difficult"]
         polyline["truncated"] = obj["truncated"]


### PR DESCRIPTION
# how to reproduce
* choose a dataset to run 「图像可视化」 and you can see `KeyError: cm` in 51 worker's docker logs

# reason
* [cm is an optional node in exported voc file](https://github.com/IndustryEssentials/ymir/blob/3e9ac6b6874d6c28474d4dce7d231739ea1703e4/ymir/command/mir/tools/data_writer.py#L197)

# things to do after pr merged
* rebuild voxel51 worker docker image in 192.168.13.144