### PR TITLE
[controller] fix annotation_type checker for label task

### DIFF
--- a/ymir/backend/src/ymir_controller/controller/label_model/label_runner.py
+++ b/ymir/backend/src/ymir_controller/controller/label_model/label_runner.py
@@ -83,5 +83,5 @@ def start_label_task(
                        repo_root=repo_root,
                        media_location=media_location,
                        import_work_dir=import_work_dir,
-                       use_pre_annotation=annotation_type is not None)
+                       use_pre_annotation=bool(annotation_type))
     logging.info("finish label task!!!")


### PR DESCRIPTION
proto 中不设置 annotation_type 时默认是 0