### PR TITLE
[backend] update version

### DIFF
--- a/ymir/command/requirements.txt
+++ b/ymir/command/requirements.txt
@@ -3,7 +3,7 @@ fasteners==0.16.3
 lmdb==1.3.0
 numpy==1.22.0
 protobuf==3.18.1
-pydantic==1.8.2
+pydantic==1.9.0
 pyyaml==5.4.1
 requests==2.25.1
 retry==0.9.2


### PR DESCRIPTION
8.31 pydantic lib upgrades to version 1.10.1, which has breaking changes affects YMIR ci (fixed in pr #1114).

pr #1114 rolls pydantic back to version 1.8.2. Unfortunately, it has issue at json exporting: not respect to config-fields, and exports unknown fields raises error at proto parsing. 

Need to upgrade to 1.9.0 that fixes this issue.