### PR TITLE
[command] pack and extract model files to different directory by stage name

### DIFF
--- a/dev_docs/ymir-cmd-container.md
+++ b/dev_docs/ymir-cmd-container.md
@@ -3,7 +3,8 @@
 | 协议文档版本 | ymir 版本 | 说明 |
 | --- | --- | --- |
 | [0.0.0](https://raw.githubusercontent.com/IndustryEssentials/ymir/release-1.1.0/docs/ymir-cmd-container.md) | 0.0.0 - 1.1.0 | 初始版本 |
-| 1.0.0 | 1.2.0 - 现在 | 增加关于中间模型的描述 |
+| [1.0.0](https://raw.githubusercontent.com/IndustryEssentials/ymir/ymir-pa/docs/ymir-cmd-container.md) | 1.2.0 - 1.2.2 | 增加关于中间模型的描述 |
+| 1.1.0 | 1.3.0 - | 4.3.2 节，训练完成后，模型保存策略更改 |
 
 ## 1. 关于此文档
 
@@ -235,7 +236,7 @@ task_0    1622552975    1    done
 | /out/log.txt | 参考共同部分 |
 | /out/monitor.txt | 参考共同部分 |
 | /out/monitor-log.txt | 参考共同部分 |
-| /out/models | 必要，最终生成的模型的输出目录，里面直接存放模型文件，没有下级子目录。<br>必须有一个 `result.yaml` 文件，格式参考注1 |
+| /out/models | 必要，最终生成的模型的输出目录，模型文件存放在以 stage_name 命名的子目录中。<br>/out/models 下必须有一个 `result.yaml` 文件，格式参考注1 |
 
 注1. `result.yaml` 文件的格式如下：
 

--- a/docker_executor/sample_executor/README.md
+++ b/docker_executor/sample_executor/README.md
@@ -96,9 +96,13 @@ app/start.py 展示了一个简单的镜像执行部分，此文档也将基于�
 
 3. 模型的保存
 
-  * 在 `EnvConfig.output.models_dir` 中提供了模型的保存目录，用户可以使用 pytorch, mxnet, darknet 等训练框架自带的保存方法将模型保存在此目录下
+  * 模型按当前正在进行的 stage name，分目录保存
 
-  * 之后，可以使用 `result_writer.write_training_result()` 方法保存训练结果的摘要，这些内容包括：不带目录的模型名称，mAP，每个类别的 APs
+  * 在 `EnvConfig.output.models_dir` 中提供了模型的保存目录，用户可以使用 pytorch, mxnet, darknet 等训练框架自带的保存方法将模型保存在此目录下的以当前 stage_name 命名的子目录中
+
+    * 例如，如果需要保存 stage_name 为 'epoch-5000' 的模型，则需要把这些模型文件保存到 `os.path.join(env.get_current_env().output.model_dir, 'epoch-5000')` 目录下
+
+  * 之后，可以使用 `result_writer.write_model_stage()` 方法保存训练结果的摘要，这些内容包括：不带目录的模型名称列表，mAP，每个类别的 APs
 
 4. 进度的记录：使用 `monitor.write_monitor_logger(percent)` 方法记录任务当前的进度，实际使用时，可以每隔若干轮迭代，根据当前迭代次数和总迭代次数来估算当前进度（一个 0 到 1 之间的数），调用此方法记录
 

--- a/docker_executor/sample_executor/app/start.py
+++ b/docker_executor/sample_executor/app/start.py
@@ -59,10 +59,12 @@ def _run_training(env_config: env.EnvConfig) -> None:
     monitor.write_monitor_logger(percent=0.5)
 
     # suppose we have a long time training, and have saved the final model
-    #! use `env_config.output.models_dir` to get model output dir
-    with open(os.path.join(env_config.output.models_dir, 'model-0000.params'), 'w') as f:
+    #! model output dir: os.path.join(env_config.output.models_dir, your_stage_name)
+    stage_dir = os.path.join(env_config.output.models_dir, 'stage_00')
+    os.makedirs(stage_dir, exist_ok=True)
+    with open(os.path.join(stage_dir, 'model-0000.params'), 'w') as f:
         f.write('fake model-0000.params')
-    with open(os.path.join(env_config.output.models_dir, 'model-symbols.json'), 'w') as f:
+    with open(os.path.join(stage_dir, 'model-symbols.json'), 'w') as f:
         f.write('fake model-symbols.json')
     #! use `rw.write_model_stage` to save training result
     rw.write_model_stage(stage_name='stage_00', files=['model-0000.params', 'model-symbols.json'], mAP=expected_mAP / 2)
@@ -71,9 +73,11 @@ def _run_training(env_config: env.EnvConfig) -> None:
 
     write_tensorboard_log(env_config.output.tensorboard_dir)
 
-    with open(os.path.join(env_config.output.models_dir, 'model-0010.params'), 'w') as f:
+    stage_dir = os.path.join(env_config.output.models_dir, 'stage_10')
+    os.makedirs(stage_dir, exist_ok=True)
+    with open(os.path.join(stage_dir, 'model-0010.params'), 'w') as f:
         f.write('fake model-0010.params')
-    with open(os.path.join(env_config.output.models_dir, 'model-symbols.json'), 'w') as f:
+    with open(os.path.join(stage_dir, 'model-symbols.json'), 'w') as f:
         f.write('fake model-symbols.json')
     rw.write_model_stage(stage_name='stage_10', files=['model-0010.params', 'model-symbols.json'], mAP=expected_mAP)
 

--- a/ymir/command/mir/commands/infer.py
+++ b/ymir/command/mir/commands/infer.py
@@ -95,8 +95,7 @@ class CmdInfer(base.BaseCommand):
         if not mir_root:
             mir_root = '.'
         if not work_dir:
-            raise MirRuntimeError(error_code=MirCode.RC_CMD_INVALID_ARGS,
-                                  error_message='empty --work-dir')
+            raise MirRuntimeError(error_code=MirCode.RC_CMD_INVALID_ARGS, error_message='empty --work-dir')
         if not index_file or not os.path.isfile(index_file):
             raise MirRuntimeError(error_code=MirCode.RC_CMD_INVALID_ARGS,
                                   error_message=f"invalid --index-file: {index_file}")
@@ -107,22 +106,18 @@ class CmdInfer(base.BaseCommand):
             raise MirRuntimeError(error_code=MirCode.RC_CMD_INVALID_ARGS,
                                   error_message='invalid run_infer and run_mining: both false')
         if not executor:
-            raise MirRuntimeError(error_code=MirCode.RC_CMD_INVALID_ARGS,
-                                  error_message='empty --executor')
+            raise MirRuntimeError(error_code=MirCode.RC_CMD_INVALID_ARGS, error_message='empty --executor')
 
         return_code = checker.check(mir_root, [checker.Prerequisites.IS_INSIDE_MIR_REPO])
         if return_code != MirCode.RC_OK:
-            raise MirRuntimeError(error_code=return_code,
-                                  error_message=f"check failed: {return_code}")
+            raise MirRuntimeError(error_code=return_code, error_message=f"check failed: {return_code}")
 
         if not executant_name:
             executant_name = task_id
 
         work_dir_in = os.path.join(work_dir, "in")
         work_dir_out = os.path.join(work_dir, "out")
-        prepare_executant_env(work_dir_in=work_dir_in,
-                              work_dir_out=work_dir_out,
-                              asset_cache_dir=media_path)
+        prepare_executant_env(work_dir_in=work_dir_in, work_dir_out=work_dir_out, asset_cache_dir=media_path)
 
         work_index_file = os.path.join(work_dir_in, 'candidate-index.tsv')
         work_config_file = os.path.join(work_dir_in, 'config.yaml')
@@ -139,13 +134,14 @@ class CmdInfer(base.BaseCommand):
         model_names = model_storage.stages[model_storage.stage_name].files
         with open(config_file, 'r') as f:
             config = yaml.safe_load(f)
-        prepare_config_file(config=config,
-                            dst_config_file=work_config_file,
-                            class_names=class_names,
-                            task_id=task_id,
-                            model_params_path=[os.path.join('/in/models', name) for name in model_names],
-                            run_infer=run_infer,
-                            run_mining=run_mining)
+        prepare_config_file(
+            config=config,
+            dst_config_file=work_config_file,
+            class_names=class_names,
+            task_id=task_id,
+            model_params_path=[os.path.join('/in/models', model_storage.stage_name, name) for name in model_names],
+            run_infer=run_infer,
+            run_mining=run_mining)
 
         env_config.generate_mining_infer_env_config_file(task_id=task_id,
                                                          run_mining=run_mining,

--- a/ymir/command/mir/commands/training.py
+++ b/ymir/command/mir/commands/training.py
@@ -126,7 +126,7 @@ def _prepare_pretrained_models(model_location: str, model_hash_stage: str, dst_m
         dst_model_dir (str): dir where you want to extract model files to
 
     Returns:
-        List[str]: model names
+        List[str]: stage_name/model_names
     """
     if not model_hash_stage:
         return []
@@ -136,7 +136,7 @@ def _prepare_pretrained_models(model_location: str, model_hash_stage: str, dst_m
                                          stage_name=stage_name,
                                          dst_model_path=dst_model_dir)
 
-    return model_storage.stages[stage_name].files
+    return [f"{stage_name}/{file_name}" for file_name in model_storage.stages[stage_name].files]
 
 
 def _get_task_parameters(config: dict) -> str:
@@ -243,9 +243,9 @@ class CmdTrain(base.BaseCommand):
         os.symlink(docker_log_src, docker_log_dst)
 
         # if have model_hash_stage, export model
-        pretrained_model_names = _prepare_pretrained_models(model_location=model_upload_location,
-                                                            model_hash_stage=pretrained_model_hash_stage,
-                                                            dst_model_dir=os.path.join(work_dir_in, 'models'))
+        pretrained_model_stage_and_names = _prepare_pretrained_models(model_location=model_upload_location,
+                                                                      model_hash_stage=pretrained_model_hash_stage,
+                                                                      dst_model_dir=os.path.join(work_dir_in, 'models'))
 
         mir_metadatas: mirpb.MirMetadatas
         mir_annotations: mirpb.MirAnnotations
@@ -317,7 +317,7 @@ class CmdTrain(base.BaseCommand):
             executor_config=executor_config,
             out_config_path=out_config_path,
             task_id=task_id,
-            pretrained_model_params=[os.path.join('/in/models', name) for name in pretrained_model_names])
+            pretrained_model_params=[os.path.join('/in/models', name) for name in pretrained_model_stage_and_names])
         env_config.generate_training_env_config_file(task_id=task_id,
                                                      env_config_file_path=os.path.join(work_dir_in, 'env.yaml'))
 

--- a/ymir/command/mir/tools/command_run_in_out.py
+++ b/ymir/command/mir/tools/command_run_in_out.py
@@ -65,6 +65,7 @@ def _cleanup_dir_sub_items(dir: str, ignored_items: Set[str]) -> None:
 
 
 def _cleanup(work_dir: str) -> None:
+    return  # todo: remove this
     if not work_dir:
         return
 

--- a/ymir/command/mir/tools/command_run_in_out.py
+++ b/ymir/command/mir/tools/command_run_in_out.py
@@ -65,7 +65,6 @@ def _cleanup_dir_sub_items(dir: str, ignored_items: Set[str]) -> None:
 
 
 def _cleanup(work_dir: str) -> None:
-    return  # todo: remove this
     if not work_dir:
         return
 

--- a/ymir/command/mir/tools/models.py
+++ b/ymir/command/mir/tools/models.py
@@ -102,14 +102,17 @@ def prepare_model(model_location: str, model_hash: str, stage_name: str, dst_mod
         model_storage.model_hash = model_hash
         model_storage.stage_name = stage_name
 
-        files: List[str]
+        entry_names: List[str]
         if stage_name:
-            files = model_storage.stages[stage_name].files
+            entry_names = [f"{stage_name}/{file_name}" for file_name in model_storage.stages[stage_name].files]
+            os.makedirs(os.path.join(dst_model_path, stage_name), exist_ok=True)
         else:
-            files = list({f for v in model_storage.stages.values() for f in v.files})
-        for file_name in files:
-            logging.info(f"    extracting {file_name} -> {dst_model_path}")
-            tar_file.extract(file_name, dst_model_path)
+            entry_names = [f"{k}/{f}" for k, v in model_storage.stages.items() for f in v.files]
+            for stage_name in model_storage.stages:
+                os.makedirs(os.path.join(dst_model_path, stage_name), exist_ok=True)
+        for name in entry_names:
+            logging.info(f"    extracting {name} -> {dst_model_path}")
+            tar_file.extract(name, dst_model_path)
 
     return model_storage
 
@@ -130,10 +133,14 @@ def pack_and_copy_models(model_storage: ModelStorage, model_dir_path: str, model
         # packing models
         for stage_name, stage in model_storage.stages.items():
             logging.info(f"  model stage: {stage_name}")
+            stage_dir = os.path.join(model_dir_path, stage_name)
             for file_name in stage.files:
-                file_path = os.path.join(model_dir_path, file_name)
-                logging.info(f"    packing {file_path} -> {file_name}")
-                tar_gz_f.add(file_path, file_name)
+                # find model file in `stage_dir`, and then `model_dir`
+                # compatible with old docker images
+                file_path = _find_model_file(model_dirs=[stage_dir, model_dir_path], file_name=file_name)
+                tar_file_key = f"{stage_name}/{file_name}"
+                logging.info(f"    packing {file_path} -> {tar_file_key}")
+                tar_gz_f.add(file_path, tar_file_key)
 
         # packing attachments
         for section, file_names in model_storage.attachments.items():
@@ -158,3 +165,11 @@ def pack_and_copy_models(model_storage: ModelStorage, model_dir_path: str, model
 
     model_storage.model_hash = model_hash
     return model_hash
+
+
+def _find_model_file(model_dirs: List[str], file_name: str) -> str:
+    for model_dir in model_dirs:
+        file_path = os.path.join(model_dir, file_name)
+        if os.path.isfile(file_path):
+            return file_path
+    raise FileNotFoundError(f"File not found: {file_name} in following dirs: {model_dirs}")

--- a/ymir/command/mir/tools/models.py
+++ b/ymir/command/mir/tools/models.py
@@ -102,15 +102,15 @@ def prepare_model(model_location: str, model_hash: str, stage_name: str, dst_mod
         model_storage.model_hash = model_hash
         model_storage.stage_name = stage_name
 
-        entry_names: List[str]
+        stage_and_file_names: List[str]
         if stage_name:
-            entry_names = [f"{stage_name}/{file_name}" for file_name in model_storage.stages[stage_name].files]
+            stage_and_file_names = [f"{stage_name}/{file_name}" for file_name in model_storage.stages[stage_name].files]
             os.makedirs(os.path.join(dst_model_path, stage_name), exist_ok=True)
         else:
-            entry_names = [f"{k}/{f}" for k, v in model_storage.stages.items() for f in v.files]
+            stage_and_file_names = [f"{k}/{f}" for k, v in model_storage.stages.items() for f in v.files]
             for stage_name in model_storage.stages:
                 os.makedirs(os.path.join(dst_model_path, stage_name), exist_ok=True)
-        for name in entry_names:
+        for name in stage_and_file_names:
             logging.info(f"    extracting {name} -> {dst_model_path}")
             tar_file.extract(name, dst_model_path)
 

--- a/ymir/command/tests/unit/test_cmd_import_model.py
+++ b/ymir/command/tests/unit/test_cmd_import_model.py
@@ -68,7 +68,7 @@ class TestCmdImportModel(unittest.TestCase):
         with open(os.path.join(self._src_model_root, 'ymir-info.yaml'), 'w') as f:
             yaml.safe_dump(model_storage.dict(), f)
         with tarfile.open(self._src_model_package_path, 'w:gz') as tar_gz_f:
-            tar_gz_f.add(os.path.join(self._src_model_root, 'best.weights'), 'best.weights')
+            tar_gz_f.add(os.path.join(self._src_model_root, 'best.weights'), f"{mss.stage_name}/best.weights")
             tar_gz_f.add(os.path.join(self._src_model_root, 'ymir-info.yaml'), 'ymir-info.yaml')
 
     def _prepare_mir_repo(self):

--- a/ymir/command/tests/unit/test_cmd_infer.py
+++ b/ymir/command/tests/unit/test_cmd_infer.py
@@ -97,8 +97,9 @@ class TestCmdInfer(unittest.TestCase):
 
         # pack model
         with tarfile.open(os.path.join(self._models_location, 'fake_model_hash'), "w:gz") as dest_tar_gz:
-            dest_tar_gz.add(os.path.join(self._models_location, 'model.params'), 'model.params')
-            dest_tar_gz.add(os.path.join(self._models_location, 'model.json'), 'model.json')
+            dest_tar_gz.add(os.path.join(self._models_location, 'model.params'),
+                            f"{model_stage.stage_name}/model.params")
+            dest_tar_gz.add(os.path.join(self._models_location, 'model.json'), f"{model_stage.stage_name}/model.json")
             dest_tar_gz.add(os.path.join(self._models_location, 'ymir-info.yaml'), 'ymir-info.yaml')
 
     def _prepare_config_file(self):
@@ -182,4 +183,4 @@ class TestCmdInfer(unittest.TestCase):
             self.assertTrue('model_params_path' in infer_config)
 
         # check model params
-        self.assertTrue(os.path.isfile(os.path.join(fake_args.work_dir, 'in', 'models', 'model.params')))
+        self.assertTrue(os.path.isfile(os.path.join(fake_args.work_dir, 'in', 'models', 'default_best_stage', 'model.params')))


### PR DESCRIPTION
* sample executor: save model files in `/out/models/<stage_name>`
* cmd tool: models:
  * when pack model files, find model files in both `<model_dir>/<stage_name>` and `<model_dir>`
  * when unpack model files, pack them to `<dst_model_dir>/<stage_name>`
* cmd training, mining and infer: when generate config, add `stage_name` to model paths
