### PR TITLE
[misc] freeze staticcheck version

### DIFF
--- a/.github/workflows/hel-pr.yml
+++ b/.github/workflows/hel-pr.yml
@@ -32,7 +32,7 @@ jobs:
       working-directory: ymir/backend/src/ymir_hel
       run: |
         time go mod verify
-        time go install honnef.co/go/tools/cmd/staticcheck@latest
+        time go install honnef.co/go/tools/cmd/staticcheck@v0.3.3
 
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3


### PR DESCRIPTION
https://github.com/dominikh/go-tools/releases/tag/2023.1 does not support Go1.18