### PR TITLE
[backend] bugfix: ck eval

### DIFF
--- a/ymir/command/mir/tools/eval/eval_ctl_ops.py
+++ b/ymir/command/mir/tools/eval/eval_ctl_ops.py
@@ -87,6 +87,8 @@ def _evaluate_on_asset_ids(gt: mirpb.SingleTaskAnnotations, pred: mirpb.SingleTa
 def _filter_task_annotations_by_asset_ids(task_annotations: mirpb.SingleTaskAnnotations,
                                           asset_ids: Collection[str]) -> mirpb.SingleTaskAnnotations:
     filtered_task_annotations = mirpb.SingleTaskAnnotations()
+    filtered_task_annotations.type = task_annotations.type
+    filtered_task_annotations.is_instance_segmentation = task_annotations.is_instance_segmentation
     for asset_id in asset_ids:
         if asset_id not in task_annotations.image_annotations:
             continue


### PR DESCRIPTION
# steps to reproduce
* when processing detection dataset evaluation, choose dataset with ck
* you will find no evaluation result for main ck and find warning: type: 0, is_instance_segmentation: false not supported
# Reason
* didn't set type and is_instance_segmentation in filtered_task_annotations