### PR TITLE
[command] bugfix: cmd copy add object annotations with unknown class ids

### DIFF
--- a/ymir/command/mir/tools/annotations.py
+++ b/ymir/command/mir/tools/annotations.py
@@ -502,7 +502,7 @@ def map_and_filter_annotations(mir_annotations: mirpb.MirAnnotations, data_label
             oa.class_id = known_cids_mapping[oa.class_id]
             oa.index = len(mapped_mir_annotations.prediction.image_annotations[asset_id].boxes)
             mapped_mir_annotations.prediction.image_annotations[asset_id].boxes.append(oa)
-    for sia in mir_annotations.ground_truth.image_annotations.values():
+    for asset_id, sia in mir_annotations.ground_truth.image_annotations.items():
         for oa in sia.boxes:
             if oa.class_id not in known_cids_mapping:
                 continue

--- a/ymir/command/mir/tools/annotations.py
+++ b/ymir/command/mir/tools/annotations.py
@@ -494,42 +494,32 @@ def map_and_filter_annotations(mir_annotations: mirpb.MirAnnotations, data_label
     }
     known_cids_mapping = {k: v for k, v in cids_mapping.items() if v >= 0}
 
-    for sia in mir_annotations.prediction.image_annotations.values():
-        boxes: List[mirpb.ObjectAnnotation] = []
+    mapped_mir_annotations = mirpb.MirAnnotations()
+    for asset_id, sia in mir_annotations.prediction.image_annotations.items():
         for oa in sia.boxes:
             if oa.class_id not in known_cids_mapping:
                 continue
             oa.class_id = known_cids_mapping[oa.class_id]
-            oa.index = len(boxes)
-            boxes.append(oa)
-        del sia.boxes[:]
-        sia.boxes.extend(boxes)
+            oa.index = len(mapped_mir_annotations.prediction.image_annotations[asset_id].boxes)
+            mapped_mir_annotations.prediction.image_annotations[asset_id].boxes.append(oa)
     for sia in mir_annotations.ground_truth.image_annotations.values():
-        boxes = []
         for oa in sia.boxes:
             if oa.class_id not in known_cids_mapping:
                 continue
             oa.class_id = known_cids_mapping[oa.class_id]
-            oa.index = len(boxes)
-            boxes.append(oa)
-        del sia.boxes[:]
-        sia.boxes.extend(boxes)
+            oa.index = len(mapped_mir_annotations.ground_truth.image_annotations[asset_id].boxes)
+            mapped_mir_annotations.ground_truth.image_annotations[asset_id].boxes.append(oa)
 
-    # exclude asset_ids with empty prediction or ground truth
-    exclude_asset_ids = [
-        asset_id for asset_id, sia in mir_annotations.prediction.image_annotations.items() if len(sia.boxes) == 0
-    ]
-    for asset_id in exclude_asset_ids:
-        del mir_annotations.prediction.image_annotations[asset_id]
-    exclude_asset_ids = [
-        asset_id for asset_id, sia in mir_annotations.ground_truth.image_annotations.items() if len(sia.boxes) == 0
-    ]
-    for asset_id in exclude_asset_ids:
-        del mir_annotations.ground_truth.image_annotations[asset_id]
+    mapped_mir_annotations.prediction.type = mir_annotations.prediction.type if len(
+        mapped_mir_annotations.prediction.image_annotations) > 0 else mirpb.ObjectType.OT_NO_ANNOS
+    mapped_mir_annotations.ground_truth.type = mir_annotations.ground_truth.type if len(
+        mapped_mir_annotations.ground_truth.image_annotations) > 0 else mirpb.ObjectType.OT_NO_ANNOS
 
-    mir_annotations.prediction.eval_class_ids[:] = [
+    mapped_mir_annotations.prediction.eval_class_ids[:] = [
         known_cids_mapping[cid] for cid in mir_annotations.prediction.eval_class_ids if cid in known_cids_mapping
     ]
+
+    mir_annotations.CopyFrom(mapped_mir_annotations)
 
     return src_class_id_mgr.main_name_for_ids(list(cids_mapping.keys() - known_cids_mapping.keys()))
 

--- a/ymir/command/mir/tools/annotations.py
+++ b/ymir/command/mir/tools/annotations.py
@@ -500,6 +500,7 @@ def map_and_filter_annotations(mir_annotations: mirpb.MirAnnotations, data_label
             if oa.class_id not in known_cids_mapping:
                 continue
             oa.class_id = known_cids_mapping[oa.class_id]
+            oa.index = len(boxes)
             boxes.append(oa)
         del sia.boxes[:]
         sia.boxes.extend(boxes)
@@ -509,6 +510,7 @@ def map_and_filter_annotations(mir_annotations: mirpb.MirAnnotations, data_label
             if oa.class_id not in known_cids_mapping:
                 continue
             oa.class_id = known_cids_mapping[oa.class_id]
+            oa.index = len(boxes)
             boxes.append(oa)
         del sia.boxes[:]
         sia.boxes.extend(boxes)

--- a/ymir/command/mir/tools/class_ids.py
+++ b/ymir/command/mir/tools/class_ids.py
@@ -153,13 +153,13 @@ class UserLabels(LabelStorage):
                     class_ids.append(class_id)
 
         if raise_if_unknown and unknown_names:
-            raise ValueError(f"unknown class found: {unknown_names}")
+            raise ValueError(f"unknown class names: {unknown_names}")
 
         return class_ids, unknown_names
 
     def main_name_for_id(self, class_id: int) -> str:
         if class_id not in self._id_to_name:
-            raise ValueError(f"copy: unknown src class id: {class_id}")
+            raise ValueError(f"unknown class id: {class_id}")
         return self._id_to_name[class_id]
 
     def main_name_for_ids(self, class_ids: List[int]) -> List[str]:

--- a/ymir/command/tests/unit/test_cmd_copy.py
+++ b/ymir/command/tests/unit/test_cmd_copy.py
@@ -69,8 +69,11 @@ class TestCmdCopy(unittest.TestCase):
         mir_annotations.prediction.image_annotations['asset1'].CopyFrom(
             self.__create_image_annotations(type_ids=[3]))
         mir_annotations.prediction.eval_class_ids[:] = eval_class_ids
-        mir_annotations.prediction.type = mirpb.ObjectType.OT_NO_ANNOS
-        mir_annotations.ground_truth.type = mirpb.ObjectType.OT_NO_ANNOS
+        mir_annotations.prediction.type = mirpb.ObjectType.OT_DET
+
+        mir_annotations.ground_truth.image_annotations['asset1'].CopyFrom(
+            self.__create_image_annotations(type_ids=[3]))
+        mir_annotations.ground_truth.type = mirpb.ObjectType.OT_DET
 
         model_meta = mirpb.ModelMeta(mAP=0.3)
         task = mir_storage_ops.create_task_record(task_type=mirpb.TaskType.TaskTypeTraining,
@@ -116,6 +119,9 @@ class TestCmdCopy(unittest.TestCase):
 
         if drop_annotations:
             self.assertEqual(0, len(mir_annotations.prediction.image_annotations))
+            self.assertEqual(mirpb.ObjectType.OT_NO_ANNOS, mir_annotations.prediction.type)
+            self.assertEqual(0, len(mir_annotations.ground_truth.image_annotations))
+            self.assertEqual(mirpb.ObjectType.OT_NO_ANNOS, mir_annotations.ground_truth.type)
         else:
             asset0_idx_ids = {
                 annotation.index: annotation.class_id
@@ -126,6 +132,8 @@ class TestCmdCopy(unittest.TestCase):
             # which is unknown to destination dataset, and to be ignored
             # so asset1 have no predictions in destination dataset, and should not appear in image_annotations
             self.assertTrue('asset1' not in mir_annotations.prediction.image_annotations)
+            self.assertEqual(mirpb.ObjectType.OT_DET, mir_annotations.prediction.type)
+            self.assertEqual(mirpb.ObjectType.OT_NO_ANNOS, mir_annotations.ground_truth.type)
         self.assertEqual(eval_class_ids_set, set(mir_annotations.prediction.eval_class_ids))
 
         mAP = mir_tasks.tasks[dst_tid].model.mAP

--- a/ymir/command/tests/unit/test_cmd_copy.py
+++ b/ymir/command/tests/unit/test_cmd_copy.py
@@ -122,7 +122,7 @@ class TestCmdCopy(unittest.TestCase):
                 for annotation in mir_annotations.prediction.image_annotations['asset0'].boxes
             }
             self.assertEqual({0: 2, 1: 2, 2: 2, 3: 1, 4: 1, 5: 1}, asset0_idx_ids)
-            # asset1 has only one prediction with class name 'd'
+            # asset1 has only prediction with class name 'd'
             # which is unknown to destination dataset, and to be ignored
             # so asset1 have no predictions in destination dataset, and should not appear in image_annotations
             self.assertTrue('asset1' not in mir_annotations.prediction.image_annotations)

--- a/ymir/command/tests/unit/test_cmd_copy.py
+++ b/ymir/command/tests/unit/test_cmd_copy.py
@@ -89,15 +89,19 @@ class TestCmdCopy(unittest.TestCase):
 
     def __create_image_annotations(self, type_ids: List[int]) -> mirpb.SingleImageAnnotations:
         single_image_annotations = mirpb.SingleImageAnnotations()
-        for idx, type_id in enumerate(type_ids):
-            annotation = mirpb.ObjectAnnotation()
-            annotation.index = idx
-            annotation.class_id = type_id
-            single_image_annotations.boxes.append(annotation)
+        for type_id in type_ids:
+            for _ in range(3):
+                annotation = mirpb.ObjectAnnotation()
+                annotation.index = len(single_image_annotations.boxes)
+                annotation.class_id = type_id
+                single_image_annotations.boxes.append(annotation)
         return single_image_annotations
 
     # private: check results
-    def __check_results(self, dst_branch: str, dst_tid: str, ignore_unknown_types: bool, drop_annotations: bool,
+    def __check_results(self,
+                        dst_branch: str,
+                        dst_tid: str,
+                        drop_annotations: bool,
                         eval_class_ids_set: Set[int] = set()):
         [mir_metadatas, mir_annotations, mir_keywords, mir_tasks,
          _] = mir_storage_ops.MirStorageOps.load_multiple_storages(
@@ -117,7 +121,7 @@ class TestCmdCopy(unittest.TestCase):
                 annotation.index: annotation.class_id
                 for annotation in mir_annotations.prediction.image_annotations['asset0'].boxes
             }
-            self.assertEqual({0: 2, 1: 1}, asset0_idx_ids)
+            self.assertEqual({0: 2, 1: 2, 2: 2, 3: 1, 4: 1, 5: 1}, asset0_idx_ids)
             # asset1 has only one prediction with class name 'd'
             # which is unknown to destination dataset, and to be ignored
             # so asset1 have no predictions in destination dataset, and should not appear in image_annotations
@@ -145,7 +149,7 @@ class TestCmdCopy(unittest.TestCase):
 
         # check result
         self.assertEqual(MirCode.RC_OK, return_code)
-        self.__check_results(dst_branch='b', dst_tid='t1', ignore_unknown_types=True, drop_annotations=False)
+        self.__check_results(dst_branch='b', dst_tid='t1', drop_annotations=False)
 
         # case 1
         fake_args = type('', (), {})()
@@ -163,7 +167,7 @@ class TestCmdCopy(unittest.TestCase):
 
         # check result
         self.assertEqual(MirCode.RC_OK, return_code)
-        self.__check_results(dst_branch='b', dst_tid='t2', ignore_unknown_types=True, drop_annotations=True)
+        self.__check_results(dst_branch='b', dst_tid='t2', drop_annotations=True)
 
         # run cmd: abnormal cases
         fake_args = type('', (), {})()
@@ -209,5 +213,5 @@ class TestCmdCopy(unittest.TestCase):
         cmd_copy = copy.CmdCopy(fake_args)
         return_code = cmd_copy.run()
         self.assertEqual(MirCode.RC_OK, return_code)
-        self.__check_results(dst_branch='b', dst_tid='t1', ignore_unknown_types=True, drop_annotations=False,
+        self.__check_results(dst_branch='b', dst_tid='t1', drop_annotations=False,
                              eval_class_ids_set={0, 2})


### PR DESCRIPTION
# how to reproduce
* create a new user
* add dataset from public dataset (of super admin)
* you can see failure
# root cause
you can remove items in a for loop of a python list, but you can not do the same thing in a for loop of a protobuf repeated field.
